### PR TITLE
small bugfix: camel case React prop allowFullScreen

### DIFF
--- a/src/app/upload/utils/tutorialPost.tsx
+++ b/src/app/upload/utils/tutorialPost.tsx
@@ -13,7 +13,7 @@ Write your article here, you can use markdown and html for it. If you never done
 
 ---
 
-<iframe src="https://ipfs.skatehive.app/ipfs/QmPdsChTSXQkqu3FLJHcAjqdLCqq5bCcnC1dKwCB8oLA1S?pinataGatewayToken=nxHSFa1jQsiF7IHeXWH-gXCY3LDLlZ7Run3aZXZc8DRCfQz4J4a94z9DmVftXyFE" autoplay={false} allowfullscreen></iframe>
+<iframe src="https://ipfs.skatehive.app/ipfs/QmPdsChTSXQkqu3FLJHcAjqdLCqq5bCcnC1dKwCB8oLA1S?pinataGatewayToken=nxHSFa1jQsiF7IHeXWH-gXCY3LDLlZ7Run3aZXZc8DRCfQz4J4a94z9DmVftXyFE" autoplay={false} allowFullScreen></iframe>
 
 ### You can use: 
 

--- a/src/components/PostModal/commentPrompt.tsx
+++ b/src/components/PostModal/commentPrompt.tsx
@@ -87,7 +87,7 @@ const CommandPrompt = ({ post, addComment }: CommandPromptProps) => {
         if (ipfsData !== undefined) {
           const ipfsUrl = `https://ipfs.skatehive.app/ipfs/${ipfsData.IpfsHash}?pinataGatewayToken=${PINATA_GATEWAY_TOKEN}`
           const markdownLink = file.type.startsWith("video/")
-            ? `<iframe src="${ipfsUrl}" allowfullscreen autoplay={false}></iframe>`
+            ? `<iframe src="${ipfsUrl}" allowFullScreen autoplay={false}></iframe>`
             : `![Image](${ipfsUrl})`
           setValue((prevMarkdown) => `${prevMarkdown}\n${markdownLink}\n`)
         }


### PR DESCRIPTION
`allowFullScreen` is camelCase in React, as opposed to how it is all lowercase in pure HTML

src:
https://react.dev/learn/writing-markup-with-jsx#3-camelcase-salls-most-of-the-things
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allowfullscreen