### PR TITLE
Upgrade User XP

### DIFF
--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -50,6 +50,7 @@ function AccountCreation() {
     const handleCheck = async () => {
         var isValidAccountName = null;
         var isAvailable = false;
+        var isEmailOk = false;
 
         setBroadcastResult(false);
         setBMessage("");
@@ -62,10 +63,12 @@ function AccountCreation() {
         if(desiredEmail==""){
             setBroadcastResult(true);
             setBMessage("You forgot the fill up the email");
-            return
+            // isEmailOk = false;
+            // return
         } else {
             setBroadcastResult(false);
             setBMessage("");
+            isEmailOk = true;
         }
 
         if (desiredUsername) {
@@ -94,16 +97,22 @@ function AccountCreation() {
                 // console.log("isAvailable: "+isAvailable);
                 //setShowSecondForm(true);
                 setAccountAvailable(true);
-                setAreKeysDownloaded(true);
-                handleGenerateKeys();
+                // setAreKeysDownloaded(true);
+                // handleGenerateKeys();
             } else {
                 // console.log("Not Available");
                 // console.log("isValidAccountName :"+isValidAccountName);
                 // console.log("isAvailable :"+isAvailable);
                 // console.log('Account already exists. Please choose a different desiredUsername.');
                 //setShowSecondForm(false);
+                
                 setAccountAvailable(false);
-                setAreKeysDownloaded(false);
+                // setAreKeysDownloaded(false);
+            }
+
+            if (isEmailOk && isAvailable && (isValidAccountName === null)) {
+                setAreKeysDownloaded(true);
+                handleGenerateKeys();
             }
         } else {
             // console.log('Please enter a username.');

--- a/src/components/Profile/levelMissions.tsx
+++ b/src/components/Profile/levelMissions.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { Mission, dummyMissions, recurringTasks } from './missionsData';
+import { Mission, dummyMissions, xpThresholds, recurringTasks } from './missionsData';
 
 interface LevelMissionsProps {
     initialLevel: number;
@@ -243,7 +243,7 @@ export default function LevelMissions({ initialLevel, user, updateAvailableXp }:
                 {/* <Tag colorScheme="green" fontSize="24px">Recurring Tasks</Tag> */}
             </Center>
 
-            <TableContainer w="100%">
+            {/* <TableContainer w="100%">
                 <Box borderRadius="15px" border="1px solid white" minW="100%">
                     <Table variant="unstyled" mt={2} color="white" w="100%">
                         <Thead>
@@ -273,8 +273,9 @@ export default function LevelMissions({ initialLevel, user, updateAvailableXp }:
                             ))}
                         </Tbody>
                     </Table>
+
                 </Box>
-            </TableContainer>
+            </TableContainer> */}
         </VStack>
     );
 }

--- a/src/components/Profile/missionsData.ts
+++ b/src/components/Profile/missionsData.ts
@@ -5,6 +5,8 @@ export interface Mission {
     imcompleted: string;
 }
 
+export const xpThresholds = [0, 180, 270, 670, 1320, 1720, 2370];
+
 export const dummyMissions: { [key: number]: Mission[] } = {
     1: [
         { name: "Add Profile Picture", xp: 30, completed: "You Looks Good", imcompleted: "You look better with a profile pic" },

--- a/src/components/Profile/profileDashboard.tsx
+++ b/src/components/Profile/profileDashboard.tsx
@@ -5,6 +5,8 @@ import { useCallback, useState } from 'react';
 import LevelMissions from './levelMissions';
 import ProfileCard from './profileCard';
 
+import { Mission, dummyMissions, xpThresholds, recurringTasks } from './missionsData';
+
 interface ProfileDashboardProps {
     user: HiveAccount;
 }
@@ -19,15 +21,14 @@ const ProfileDashboard = ({ user }: ProfileDashboardProps) => {
     const userXp = extensions?.staticXp || 0;
     const [availableXp, setAvailableXp] = useState(userXp);
 
-    const steps = [
-        { title: 'Level 1', description: 'start' },
-        { title: 'Level 2', description: 'min. 180 xp' },
-        { title: 'Level 3', description: 'min. 270 xp' },
-        { title: 'Level 4', description: 'min. 540 xp' },
-        { title: 'Level 5', description: 'min. 720 xp' },
-        { title: 'Level 6', description: 'min. 900 xp' },
-        { title: 'Level 7', description: 'min. 1080 xp' },
-    ];
+    const steps = [{ title: 'Level 1', description: 'start' },];
+    for (let i = 2; i <= xpThresholds.length; i++) {
+        const step = {
+            title: `Level ${i}`,
+            description: `min. ${xpThresholds[i]} xp`
+        };
+        steps.push(step);
+    }
 
     const filteredSteps = steps.filter((step, index) => {
         const start = Math.max(0, userLevel - 2);
@@ -37,7 +38,7 @@ const ProfileDashboard = ({ user }: ProfileDashboardProps) => {
         else
             end = Math.min(steps.length - 1, userLevel + 3);
         return index >= start && index <= end;
-      });
+    });
 
     const updateAvailableXp = useCallback((xp: number) => {
         // console.log(`Updating available XP to: ${xp}`);
@@ -46,7 +47,7 @@ const ProfileDashboard = ({ user }: ProfileDashboardProps) => {
 
     function Levels() {
         var activeLevel = userLevel;
-        activeLevel = filteredSteps.indexOf(steps[userLevel])-1;
+        activeLevel = filteredSteps.indexOf(steps[userLevel]) - 1;
 
         const { activeStep } = useSteps({
             index: activeLevel,
@@ -56,7 +57,8 @@ const ProfileDashboard = ({ user }: ProfileDashboardProps) => {
         return (
             <Box m={10}>
                 <Stepper sx={{
-                    "&::-webkit-scrollbar": {display: "none",}}}
+                    "&::-webkit-scrollbar": { display: "none", }
+                }}
                     overflowX="auto" size='lg' colorScheme='green' index={activeStep}>
 
                     {filteredSteps.map((step, index) => (


### PR DESCRIPTION
1. a temporary fix to handle user level up.
2. removed xp from card header so names with 16 chars can fit on the card.
3. include a Toast() to message user that upgrade are not available yet.
4. removed recurring tasks
5. xpThresholds shared among modules
6. remove user preview card before broadcast to blockchain