### PR TITLE
 Fix: Prevent MarkdownRenderer from breaking layout

### DIFF
--- a/src/app/post/ClientMarkdownRenderer.tsx
+++ b/src/app/post/ClientMarkdownRenderer.tsx
@@ -12,10 +12,10 @@ const ClientMarkdownRenderer: React.FC<ClientMarkdownRendererProps> = ({ content
     const transformedContent = content.replace("ipfs.skatehive.app", PINATA_URL);
 
     return (
-        <>
+      <div style={{ fontSize: '16px', lineHeight: '1.6', color: 'white' }}>
             <MarkdownRenderer content={transformedContent} />
-        </>
-    );
+      </div>
+  );
 };
 
 export default ClientMarkdownRenderer;


### PR DESCRIPTION
Change:
Fixed MarkdownRenderer, which was previously breaking the display, by adding a <div> with default styles.

Objective:
Prevent the rendered Markdown content from breaking the page layout by applying default styling to ensure a consistent display for all posts.